### PR TITLE
fast multiplication with u64 scalars

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,11 @@ num-traits = { version = "0.2", optional = true }
 [features]
 default = ["sec2"]
 
+# Fast scalar multiplication for scalars that are represented as u64. This
+# multiplication implementation exits early (upon reaching the first leading
+# zero) so it could be subject to side-channel attacks.
+fast-u64-scalar-mul = []
+
 # SEC2 curves enabled by default (192, 224 are probably too small in 2020)
 sec2 = ["p192k1", "p192r1", "p224k1", "p224r1", "p256k1", "p256r1", "p384r1", "p521r1"]
 

--- a/src/curve/fiat/curve_macros.rs
+++ b/src/curve/fiat/curve_macros.rs
@@ -165,7 +165,6 @@ macro_rules! fiat_define_weierstrass_points {
 
             fn mul(self, other: &'b Scalar) -> Point {
                 self.scale(other)
-                //Point(self.0.scale_a0(&other.to_bytes(), Curve))
             }
         }
 
@@ -174,6 +173,24 @@ macro_rules! fiat_define_weierstrass_points {
 
             fn mul(self, other: &'b Point) -> Point {
                 other * self
+            }
+        }
+
+        #[cfg(feature = "fast-u64-scalar-mul")]
+        impl<'a> std::ops::Mul<u64> for &'a Point {
+            type Output = Point;
+
+            fn mul(self, other: u64) -> Point {
+                self.scale_u64(other)
+            }
+        }
+
+        #[cfg(feature = "fast-u64-scalar-mul")]
+        impl<'a> std::ops::Mul<&'a Point> for u64 {
+            type Output = Point;
+
+            fn mul(self, other: &'a Point) -> Point {
+                other.scale_u64(self)
             }
         }
 

--- a/src/curve/sec2/p192k1.rs
+++ b/src/curve/sec2/p192k1.rs
@@ -167,6 +167,10 @@ impl Point {
     fn scale<'b>(&self, other: &'b Scalar) -> Self {
         Point(self.0.scale_a0(&other.to_bytes(), Curve))
     }
+    #[cfg(feature = "fast-u64-scalar-mul")]
+    fn scale_u64(&self, other: u64) -> Self {
+        Point(self.0.scale_a0_u64(other, Curve))
+    }
 }
 
 #[cfg(test)]

--- a/src/curve/sec2/p192r1.rs
+++ b/src/curve/sec2/p192r1.rs
@@ -153,6 +153,10 @@ impl Point {
     fn scale<'b>(&self, other: &'b Scalar) -> Self {
         Point(self.0.scale(&other.to_bytes(), Curve))
     }
+    #[cfg(feature = "fast-u64-scalar-mul")]
+    fn scale_u64(&self, other: u64) -> Self {
+        Point(self.0.scale_u64(other, Curve))
+    }
 }
 
 #[cfg(test)]

--- a/src/curve/sec2/p224k1.rs
+++ b/src/curve/sec2/p224k1.rs
@@ -188,6 +188,10 @@ impl Point {
     fn scale<'b>(&self, other: &'b Scalar) -> Self {
         Point(self.0.scale_a0(&other.to_bytes(), Curve))
     }
+    #[cfg(feature = "fast-u64-scalar-mul")]
+    fn scale_u64(&self, other: u64) -> Self {
+        Point(self.0.scale_a0_u64(other, Curve))
+    }
 }
 
 #[cfg(test)]

--- a/src/curve/sec2/p224r1.rs
+++ b/src/curve/sec2/p224r1.rs
@@ -215,6 +215,10 @@ impl Point {
     fn scale<'b>(&self, other: &'b Scalar) -> Self {
         Point(self.0.scale(&other.to_bytes(), Curve))
     }
+    #[cfg(feature = "fast-u64-scalar-mul")]
+    fn scale_u64(&self, other: u64) -> Self {
+        Point(self.0.scale_u64(other, Curve))
+    }
 }
 
 #[cfg(test)]

--- a/src/curve/sec2/p256k1.rs
+++ b/src/curve/sec2/p256k1.rs
@@ -175,6 +175,10 @@ impl Point {
     fn scale<'b>(&self, other: &'b Scalar) -> Self {
         Point(self.0.scale_a0(&other.to_bytes(), Curve))
     }
+    #[cfg(feature = "fast-u64-scalar-mul")]
+    fn scale_u64(&self, other: u64) -> Self {
+        Point(self.0.scale_a0_u64(other, Curve))
+    }
 }
 
 #[cfg(test)]

--- a/src/curve/sec2/p256r1.rs
+++ b/src/curve/sec2/p256r1.rs
@@ -168,6 +168,10 @@ impl Point {
     fn scale<'b>(&self, other: &'b Scalar) -> Self {
         Point(self.0.scale(&other.to_bytes(), Curve))
     }
+    #[cfg(feature = "fast-u64-scalar-mul")]
+    fn scale_u64(&self, other: u64) -> Self {
+        Point(self.0.scale_u64(other, Curve))
+    }
 }
 
 #[cfg(test)]

--- a/src/curve/sec2/p384r1.rs
+++ b/src/curve/sec2/p384r1.rs
@@ -189,6 +189,10 @@ impl Point {
     fn scale<'b>(&self, other: &'b Scalar) -> Self {
         Point(self.0.scale(&other.to_bytes(), Curve))
     }
+    #[cfg(feature = "fast-u64-scalar-mul")]
+    fn scale_u64(&self, other: u64) -> Self {
+        Point(self.0.scale_u64(other, Curve))
+    }
 }
 
 #[cfg(test)]

--- a/src/curve/sec2/p521r1.rs
+++ b/src/curve/sec2/p521r1.rs
@@ -183,6 +183,10 @@ impl Point {
     fn scale<'b>(&self, other: &'b Scalar) -> Self {
         Point(self.0.scale(&other.to_bytes(), Curve))
     }
+    #[cfg(feature = "fast-u64-scalar-mul")]
+    fn scale_u64(&self, other: u64) -> Self {
+        Point(self.0.scale_u64(other, Curve))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This multiplication implementation exits early (upon reaching the first
leading zero). Due to that it is useful for small scalars that fit into
u64.

Could be subject to side-channel attacks and is initially designed for
environments where the performance is critical while preserving constant
execution time or energy consumption is not.

Co-Authored-By: Giacomo Pasini <giacomo.pasini@iohk.io>